### PR TITLE
shared edges correction

### DIFF
--- a/snitt.py
+++ b/snitt.py
@@ -26,7 +26,7 @@ def filter_pairs(h, known_pairs):
     n_unique = 0
     for line in h:
         a, b = line.split()
-        if (a,b) in known_pairs:
+        if (a,b) in known_pairs or (b,a) in known_pairs:
             n_shared += 1
         else:
             n_unique += 1


### PR DESCRIPTION
n_shared ökar med 1 nu även om (b,a) finns i known_pairs och inte bara om (a,b) finns i known_pairs.